### PR TITLE
Fix celery task run which had some few issues

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,7 +20,7 @@ RUN apk update && \
     pip install --no-cache-dir -r requirements.txt
 
 # Copy the Celery configuration file into the container
-COPY ./file_upload_service/celery.py /app/
+COPY ./file_upload_service/celery_conf.py /app/
 
 # Set the environment variable for the Celery command
 ENV C_FORCE_ROOT=1

--- a/api/models.py
+++ b/api/models.py
@@ -50,10 +50,9 @@ class File(models.Model):
     @transition(field=status, source='new', target='processing')
     def process_file(self):
         try:
-            handle_uploaded_file(self.file)
+            # handle_uploaded_file(self.file)
             # Spawn a new Celery task for processing the file data
-           
-            # handle_uploaded_file_task.apply_async(args=[self.file.path])
+            handle_uploaded_file_task.apply_async(args=[self.file.path])
             self.complete_processing()
         except Exception as e:
             print(f"An error occurred while processing the file: {e}")

--- a/api/tasks.py
+++ b/api/tasks.py
@@ -1,6 +1,7 @@
 from celery import shared_task
 from .upload_file_data import handle_uploaded_file
 
+
 @shared_task()
 def handle_uploaded_file_task(file):
     """Creates a task for handling the creation of the users data in the uploaded file."""

--- a/api/upload_file_data.py
+++ b/api/upload_file_data.py
@@ -53,23 +53,27 @@ def get_rows(steps,count,file):
                 df = pd.DataFrame(data)
     return df
 
-def handle_uploaded_file(file): 
+def handle_uploaded_file(file_path): 
     steps = 2000
     n = 0
     count = 0
 
-    while True:
+    with open(file_path, "r") as file:
+        print(file)
 
-        df = get_rows(steps,count, file)
+        while True:
 
-        create_users(df)
+            df = get_rows(steps,count, file)
 
-        n+=len(df)
-        
-        count+=1
-        
-        if len(df)!=steps:
-            break
+            create_users(df)
+
+            n+=len(df)
+            
+            count+=1
+            
+            if len(df)!=steps:
+                break
+    file.close()
 
     print(f"We have completed batch processing of the users data. Total number processed is: {n}") 
 

--- a/api/upload_file_data.py
+++ b/api/upload_file_data.py
@@ -59,8 +59,6 @@ def handle_uploaded_file(file_path):
     count = 0
 
     with open(file_path, "r") as file:
-        print(file)
-
         while True:
 
             df = get_rows(steps,count, file)

--- a/file_upload_service/__init__.py
+++ b/file_upload_service/__init__.py
@@ -1,3 +1,3 @@
-from .celery import app as celery_app
+from .celery_conf import app as celery_app
 
 __all__ = ("celery_app",)

--- a/file_upload_service/celery_conf.py
+++ b/file_upload_service/celery_conf.py
@@ -1,4 +1,6 @@
 import os
+os.environ['DJANGO_SETTINGS_MODULE'] = "file_upload_service.settings"
+
 from celery import Celery
 import django
 django.setup()

--- a/file_upload_service/settings.py
+++ b/file_upload_service/settings.py
@@ -171,3 +171,8 @@ FSM_LOG_IGNORED_MODELS = (
     'auth.User',
     'auth.Group',
 )
+
+DJANGO_FSM_LOG_IGNORED_MODELS = (
+    'auth.User',
+    'auth.Group',
+)


### PR DESCRIPTION
## Problem
 There were some failures noted today with the celery task. This was because the celery task was receiving a file object in the `args` yet it expects a json serializable object. It can also not accept an already opened file.

## Solution
Pass the file path to the celery task and then open the file for processing upstream