### PR TITLE
Add a start.sh to manage when docker images are created

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -38,6 +38,12 @@ EXPOSE 8000
 # Define environment variables
 ENV DJANGO_SETTINGS_MODULE=file_upload_service.settings
 
+# Copy the boot.sh file into the container and set its permissions
+# COPY ./bin/start.sh /app/
+
+RUN chmod +x ./bin/start.sh
+
 # Start the server
-CMD ["python3", "manage.py", "runserver", "0.0.0.0:8000"]
+# CMD ["python3", "manage.py", "runserver", "0.0.0.0:8000"]
+CMD ["bash", "-c", "./bin/start.sh && python3 manage.py runserver 0.0.0.0:8000"]
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -32,6 +32,9 @@ RUN pip install --no-cache-dir -r requirements.txt
 # Copy the entire application directory into the container at /app
 COPY . /app/
 
+# update permissions of the uploads folder to root user
+RUN mkdir -p /app/uploads && chown -R root:root /app/uploads
+
 # Expose port 8000
 EXPOSE 8000
 

--- a/bin/start.sh
+++ b/bin/start.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# wait for Postgres to start
+function postgres_ready(){
+python3 << END
+import sys
+import psycopg2
+try:
+    conn = psycopg2.connect(dbname="postgres", user="postgres", password="postgres", host="postgres")
+    conn.close () 
+except psycopg2.OperationalError:
+    sys.exit(-1)
+sys.exit(0)
+END
+}
+
+until postgres_ready; do
+  >&2 echo "Postgres is unavailable - sleeping"
+  sleep 1
+done
+
+# Collect static files
+echo "Collect static files"
+python3 manage.py collectstatic --noinput
+
+# Apply database migrations
+echo "Apply database migrations"
+python3 manage.py migrate
+
+# Start server
+echo "Starting server"
+python3 manage.py runserver 0.0.0.0:8000

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -37,6 +37,7 @@ services:
     command: python3 manage.py runserver 0.0.0.0:8000 
     volumes:
       - .:/code
+      - ./uploads:/app/uploads
     ports:
       - "8000:8000"
     depends_on:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,11 +29,12 @@ services:
       - redis
     environment:
       - DJANGO_SETTINGS_MODULE=file_upload_service.settings
-      - CELERY_BROKER_URL=redis://redis:6380
-      - CELERY_RESULT_BACKEND=redis://redis:6380
+      - CELERY_BROKER_URL=redis://redis:6379/0
+      - CELERY_RESULT_BACKEND=redis://redis:6379/0
   web:
     build: .
-    command: python3 manage.py runserver 0.0.0.0:8000
+    # command: sh -c './bin/start.sh && python3 manage.py runserver 0.0.0.0:8000'
+    command: python3 manage.py runserver 0.0.0.0:8000 
     volumes:
       - .:/code
     ports:


### PR DESCRIPTION
## Problem

The app seems to be unable to access the Postgres database. This is probably caused by the app starting before the database has started. When you check the network, all containers are running but the when you check `web` logs, you see connection errors

## Solution

Create a `start.sh` file where we check if the database is ready for connections then deploy the app and run the migrations